### PR TITLE
fix(web): static assets in container

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -54,6 +54,6 @@ COPY --from=installer /app/apps/web/package.json .
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
-COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./.next/static
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 
 CMD node apps/web/server.js


### PR DESCRIPTION
## **Description**

- used the wrong path for static assets in the docker image

## **Issues**

- Any associated issues or features that this PR corresponds to.
