### PR TITLE
fix(web/account): account connected typo

### DIFF
--- a/apps/web/pages/account.tsx
+++ b/apps/web/pages/account.tsx
@@ -275,7 +275,7 @@ export default function Account() {
                                         md: 15,
                                       }}
                                     >
-                                      Your are connected to a {name} account.
+                                      You are connected to a {name} account.
                                     </Text>
                                   </Flex>
                                   {name.toUpperCase() !=


### PR DESCRIPTION
Your are connected to a {name} account. => You are connected to a {name} account.

## **Description**
- Fixes a typo I noticed in the /account page of the website.
**Your** are connected to a {name} account. => **You** are connected to a {name} account.`

- [ x ] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
