### PR TITLE
add nonce to csp for cf turnstile

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -19,7 +19,7 @@ const securityHeaders = [
   {
     key: 'Content-Security-Policy',
     value:
-      "default-src 'self'; img-src * data:; script-src 'self' 'unsafe-eval' https://challenges.cloudflare.com/; connect-src 'self' https://youtube.com https://www.youtube.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com https://youtube.com https://www.youtube.com; upgrade-insecure-requests;",
+      "default-src 'self'; img-src * data:; script-src 'self' 'nonce-ch4hvvbHDpv7xCSvXCs3BrNggHdTzxUA' 'unsafe-eval' https://challenges.cloudflare.com/; connect-src 'self' https://youtube.com https://www.youtube.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com https://youtube.com https://www.youtube.com; upgrade-insecure-requests;",
   },
 ];
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -19,7 +19,7 @@ const securityHeaders = [
   {
     key: 'Content-Security-Policy',
     value:
-      "default-src 'self'; img-src * data:; script-src 'self' 'nonce-ch4hvvbHDpv7xCSvXCs3BrNggHdTzxUA' 'unsafe-eval' https://challenges.cloudflare.com/; connect-src 'self' https://youtube.com https://www.youtube.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com https://youtube.com https://www.youtube.com; upgrade-insecure-requests;",
+      "default-src 'self'; img-src * data:; script-src 'self' 'sha256-ac1zrQEmy3XGPb0cfRRfRfJrTtI7BslOmDFWYr9sDbQ=' 'unsafe-eval' https://challenges.cloudflare.com/; connect-src 'self' https://youtube.com https://www.youtube.com; style-src 'self' 'unsafe-inline'; frame-src https://challenges.cloudflare.com https://youtube.com https://www.youtube.com; upgrade-insecure-requests;",
   },
 ];
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -61,7 +61,7 @@ const nextConfig = {
   async headers() {
     if (process.env.NODE_ENV === 'production') {
       securityHeaders[4].value =
-        "default-src 'self'; img-src * data:; script-src 'self' https://challenges.cloudflare.com/; style-src 'self' 'unsafe-inline'; connect-src 'self' https://youtube.com https://www.youtube.com; frame-src https://challenges.cloudflare.com https://youtube.com https://www.youtube.com; upgrade-insecure-requests;";
+        "default-src 'self'; img-src * data:; script-src 'self' 'sha256-ac1zrQEmy3XGPb0cfRRfRfJrTtI7BslOmDFWYr9sDbQ=' https://challenges.cloudflare.com/; style-src 'self' 'unsafe-inline'; connect-src 'self' https://youtube.com https://www.youtube.com; frame-src https://challenges.cloudflare.com https://youtube.com https://www.youtube.com; upgrade-insecure-requests;";
     }
     return [
       {

--- a/apps/web/pages/submissions/upload.tsx
+++ b/apps/web/pages/submissions/upload.tsx
@@ -89,6 +89,8 @@ export default function Upload() {
     { name: 'VALORANT', shortName: 'val' },
     { name: 'Team Fortress 2', shortName: 'tf2' },
     { name: 'Apex Legends', shortName: 'ape' },
+    { name: 'Call of Duty: Warzone', shortName: 'cod' },
+    { name: 'Rainbow Six Siege', shortName: 'r6s' },
   ];
   const cheatsArray = [
     { name: 'NOCHEAT' },


### PR DESCRIPTION
## **Description**

- adds a nonce to the csp headers that cf can detect with cdn and inject

## **Issues**

- N/A

---

- [x] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
