### PR TITLE
feat(web/dashboard): blur email addresses in the dashboard

### DIFF
--- a/apps/web/pages/dash/users.tsx
+++ b/apps/web/pages/dash/users.tsx
@@ -38,6 +38,8 @@ import { BsFillExclamationOctagonFill } from 'react-icons/bs';
 import { unstable_getServerSession } from 'next-auth/next';
 import { authOptions } from '../api/auth/[...nextauth]';
 import { ReactElement } from 'react';
+
+import styles from '../../styles/dash/Users.module.css';
 interface GoToItem {
   number: number;
 }
@@ -253,7 +255,7 @@ export default function User() {
                           </Text>
                         </Td>
                         <Td>
-                          <Text fontSize={15}>{result.email}</Text>
+                          <Text fontSize={15} className={styles.private}>{result.email}</Text>
                         </Td>
                         <Td>
                           <Text fontSize={15}>

--- a/apps/web/styles/dash/Users.module.css
+++ b/apps/web/styles/dash/Users.module.css
@@ -1,0 +1,15 @@
+.private {
+    filter: blur(5px);
+}
+
+.private:hover {
+    filter: none;
+}
+
+.private:active {
+    filter: none;
+}
+
+.private:focus {
+    filter: none;
+}


### PR DESCRIPTION
Blurs email addresses in the dashboard unless hovered to prevent accidental leaks of information

## **Description**

- Adds a feature where email addresses are blurred in the dashboard.
- Introduces a `styles` folder for custom CSS.

## **Issues**

- N/A

---

- [ ] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
