### PR TITLE
fixed typo: changed started to start

### DIFF
--- a/docs/src/pages/en/getting-started.md
+++ b/docs/src/pages/en/getting-started.md
@@ -6,7 +6,7 @@ layout: ../../layouts/MainLayout.astro
 
 ## Prerequisites
 
-Before you can started hacking away on waldo, you need to have the tools below to ensure everything works.
+Before you can start hacking away on waldo, you need to have the tools below to ensure everything works.
 
 - Node.js - The current `LTS` version
 - Rust - So our desktop app can build


### PR DESCRIPTION
## **Description**

This change resolves #192 by changing "Before you can started hacking away on waldo, you need to have the tools below to ensure everything works." to "Before you can start hacking away on waldo, you need to have the tools below to ensure everything works."

## **Issues**

 #192

- [X ] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
