### PR TITLE
docs: fix getting started page

### DIFF
--- a/docs/src/pages/en/getting-started.md
+++ b/docs/src/pages/en/getting-started.md
@@ -1,4 +1,4 @@
-        ---
+---
 title: Getting Started
 description: Getting started with contributing to Waldo Vision
 layout: ../../layouts/MainLayout.astro


### PR DESCRIPTION
## **Description**

- fixes getting started page in docs

## **Issues**

- currently the getting started page styling is broken

---

- [x] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
