### PR TITLE
Add Debug OAuth provider & emulator for development only. Add alternative to external account provider

### DIFF
--- a/apps/web/auth-providers/debug_login.ts
+++ b/apps/web/auth-providers/debug_login.ts
@@ -1,39 +1,43 @@
 import { OAuthConfig, OAuthUserConfig } from 'next-auth/providers';
 
-export interface DebugLoginProfile extends Record<string, any> {
-  sub: string;
-  battle_tag: string;
-}
-
-export default function DebugLoginProvider<P extends DebugLoginProfile>(
+/*
+ * This here is the Authenticator provider for OAuth emulation, to use Login functionality
+ * without neerding to register your own app at github & others. It is still experimental though
+ * so use at your onw risk.
+ * And do not forget to set your NEXTAUTH_URL to the url the site is hosted at: for example local dev:
+ * NEXTAUTH_URL="http://localhost:3000"
+ */
+export default function DebugLoginProvider<P>(
   options: OAuthUserConfig<P>,
 ): OAuthConfig<P> {
   return {
-    id: 'debuglogin',
+    id: 'experimental_debug_login',
     name: 'Debug Login',
     type: 'oauth',
     version: '2.0',
     authorization: {
-      url: 'http://localhost:3000/api/debug_oauth_emulator',
+      url: process.env.NEXTAUTH_URL + '/api/auth/debug_oauth_emulator',
       params: {
         grant_type: 'authorization_code',
         scope: 'openid',
       },
     },
     token: {
-      url: 'http://localhost:3000/api/debug_oauth_emulator',
+      url: process.env.NEXTAUTH_URL + '/api/auth/debug_oauth_emulator',
     },
     userinfo: {
-      url: 'http://localhost:3000/api/debug_oauth_emulator?userinfo=yes',
+      url:
+        process.env.NEXTAUTH_URL +
+        '/api/auth/debug_oauth_emulator?userinfo=yes',
     },
     idToken: false,
     async profile() {
+      //Edit here, if you want other profile details
       return {
-        id: '2',
-        name: 'TestUser',
+        id: '1',
+        name: 'DebugLoginUser',
         email: null,
-        image:
-          'https://waldo.vision/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Fandroid-chrome-256x256.47d544ec.png&w=256&h=256&q=100',
+        image: 'noimage',
       };
     },
     options,

--- a/apps/web/auth-providers/debug_login.ts
+++ b/apps/web/auth-providers/debug_login.ts
@@ -1,0 +1,41 @@
+import { OAuthConfig, OAuthUserConfig } from 'next-auth/providers';
+
+export interface DebugLoginProfile extends Record<string, any> {
+  sub: string;
+  battle_tag: string;
+}
+
+export default function DebugLoginProvider<P extends DebugLoginProfile>(
+  options: OAuthUserConfig<P>,
+): OAuthConfig<P> {
+  return {
+    id: 'debuglogin',
+    name: 'Debug Login',
+    type: 'oauth',
+    version: '2.0',
+    authorization: {
+      url: 'http://localhost:3000/api/debug_oauth_emulator',
+      params: {
+        grant_type: 'authorization_code',
+        scope: 'openid',
+      },
+    },
+    token: {
+      url: 'http://localhost:3000/api/debug_oauth_emulator',
+    },
+    userinfo: {
+      url: 'http://localhost:3000/api/debug_oauth_emulator?userinfo=yes',
+    },
+    idToken: false,
+    async profile() {
+      return {
+        id: '2',
+        name: 'TestUser',
+        email: null,
+        image:
+          'https://waldo.vision/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Fandroid-chrome-256x256.47d544ec.png&w=256&h=256&q=100',
+      };
+    },
+    options,
+  };
+}

--- a/apps/web/pages/account.tsx
+++ b/apps/web/pages/account.tsx
@@ -55,6 +55,15 @@ const ProvidersList: Array<ProvidersListType> = [
     name: 'Github',
     icon: <BsGithub size={30} color={'#000000'} />,
   },
+  ...(process.env.NODE_ENV === 'development' //add debug login to fronted account list if development mode.
+    ? [
+        {
+          name: 'experimental_debug_login', //this needs to be the id field of provider, else it will not work,
+          // because name == id due to some reason
+          icon: <BsGithub size={30} color={'#000000'} />, //just to satisfy nodejs
+        },
+      ]
+    : []),
 ];
 
 export interface Gameplay {

--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -64,11 +64,16 @@ export const authOptions = {
       clientSecret: process.env.TWITCH_CLIENT_SECRET,
       issuer: 'https://id.twitch.tv/oauth2/authorize',
     }),
-    DebugLoginProvider({
-      //debug login provider connecting to emulated oauth
-      clientId: 'DEBUGCLIENTID', //these here are only needed for typescript
-      clientSecret: 'DEBUGCLIENTSECRET',
-    }),
+    //if dev mode add debugloginprovder to provider list to backend
+    ...(process.env.NODE_ENV === 'development'
+      ? [
+          DebugLoginProvider({
+            //debug login provider connecting to emulated oauth
+            clientId: 'DEBUGCLIENTID', //these here are only needed for typescript, not used for validation
+            clientSecret: 'DEBUGCLIENTSECRET',
+          }),
+        ]
+      : []),
   ],
   callbacks: {
     async session(sessionCallback: SessionCallback) {

--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -11,6 +11,7 @@ import { Profile, Session, User } from 'next-auth';
 import { Roles } from 'database';
 import { Account } from 'next-auth';
 import { Adapter } from 'next-auth/adapters';
+import DebugLoginProvider from '@auth-providers/debug_login';
 
 const RicanGHId = '59850372';
 const HomelessGHId = '30394883';
@@ -31,8 +32,8 @@ interface RedirectCallback {
 
 const adapter = {
   ...PrismaAdapter(prisma),
-  linkAccount: ({ sub, ...data }: any) => prisma.account.create({ data })
-} as Adapter
+  linkAccount: ({ sub, ...data }: any) => prisma.account.create({ data }),
+} as Adapter;
 
 export const authOptions = {
   adapter,
@@ -62,6 +63,11 @@ export const authOptions = {
       clientId: process.env.TWITCH_CLIENT_ID,
       clientSecret: process.env.TWITCH_CLIENT_SECRET,
       issuer: 'https://id.twitch.tv/oauth2/authorize',
+    }),
+    DebugLoginProvider({
+      //debug login provider connecting to emulated oauth
+      clientId: 'DEBUGCLIENTID', //these here are only needed for typescript
+      clientSecret: 'DEBUGCLIENTSECRET',
     }),
   ],
   callbacks: {

--- a/apps/web/pages/api/auth/debug_oauth_emulator.ts
+++ b/apps/web/pages/api/auth/debug_oauth_emulator.ts
@@ -5,9 +5,15 @@ This here is a simple oauth2 emulator used by the debug login option, to allow w
 this always log you in, but return no data, since that is handled in the debug_login module
 */
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  console.log('Called API' + req.method + req.url);
-  if (req.url == null) {
+  if (process.env.NODE_ENV === 'production') {
+    //do not enable this in production
     res.status(404);
+    return;
+  }
+  if (req.url == null) {
+    //if no url is specified also deny
+    res.status(404);
+    return;
   }
   const urlsearchparams = new URL(req.url, `http://${req.headers.host}`)
     .searchParams;
@@ -27,11 +33,11 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     //this gets queried by the nextauth framework
     res.status(200).json({
       token_type: 'Bearer',
-      expires_in: 217590, //basically forever, since refresh isn't implemented here TODO WARNING: the database only supports 4 bit integers on this value
+      expires_in: 31536000, //1 year, since refresh is not implemented WARNING: the database only supports 4 bit integers on this value, RFC does not specify max length
       access_token: 'OAuthEmulatorAccesToken',
       scope: 'openid',
       refresh_token: 'OAuthEmulatorRefreshToken',
     });
   }
-  res.status(200).json('No info for you, since not needed');
+  res.status(200).json('No info for you, since not needed'); //This should be account data, but since auth-provdier sets profile, it is not needed.
 }

--- a/apps/web/pages/api/debug_oauth_emulator.tsx
+++ b/apps/web/pages/api/debug_oauth_emulator.tsx
@@ -1,0 +1,37 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+/*
+This here is a simple oauth2 emulator used by the debug login option, to allow website testing, without needing to configure oauth projects on external providers,
+this always log you in, but return no data, since that is handled in the debug_login module
+*/
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  console.log('Called API' + req.method + req.url);
+  if (req.url == null) {
+    res.status(404);
+  }
+  const urlsearchparams = new URL(req.url, `http://${req.headers.host}`)
+    .searchParams;
+  const redirect_uri = urlsearchparams.get('redirect_uri');
+  const state = urlsearchparams.get('state');
+  if (redirect_uri != null && req.method === 'GET') {
+    //here the web browser queries the stuff
+    res
+      .status(302)
+      .setHeader(
+        'Location',
+        redirect_uri + '?state=' + state + '&code=youdontneedanyaccescodeslolz',
+      )
+      .json('');
+    return;
+  } else if (req.method === 'POST') {
+    //this gets queried by the nextauth framework
+    res.status(200).json({
+      token_type: 'Bearer',
+      expires_in: 217590, //basically forever, since refresh isn't implemented here TODO WARNING: the database only supports 4 bit integers on this value
+      access_token: 'OAuthEmulatorAccesToken',
+      scope: 'openid',
+      refresh_token: 'OAuthEmulatorRefreshToken',
+    });
+  }
+  res.status(200).json('No info for you, since not needed');
+}

--- a/apps/web/pages/auth/login.tsx
+++ b/apps/web/pages/auth/login.tsx
@@ -131,9 +131,9 @@ export default function Login() {
       },
     ];
     if (process.env.NODE_ENV === 'development') {
-      //add debug login if development mode
+      //add debug login if development mode to frontend login page
       providers.unshift({
-        provider: 'Debug Login',
+        provider: 'experimental_debug_login', //this needs to be the id field of provider, else it will not work
         hex: '#00FF00',
         selected: false,
       });

--- a/apps/web/pages/auth/login.tsx
+++ b/apps/web/pages/auth/login.tsx
@@ -28,6 +28,7 @@ import { FaDiscord, FaBattleNet, FaTwitch } from 'react-icons/fa';
 import { FcGoogle } from 'react-icons/fc';
 import { BsGithub, BsFacebook } from 'react-icons/bs';
 import Head from 'next/head';
+
 type Provider = {
   provider: string;
   hex?: string;
@@ -129,6 +130,14 @@ export default function Login() {
         selected: false,
       },
     ];
+    if (process.env.NODE_ENV === 'development') {
+      //add debug login if development mode
+      providers.unshift({
+        provider: 'Debug Login',
+        hex: '#00FF00',
+        selected: false,
+      });
+    }
     retrieveUserSession();
     setAuthProviders(providers);
   }, []);

--- a/docs/src/pages/en/getting-started.md
+++ b/docs/src/pages/en/getting-started.md
@@ -91,6 +91,13 @@ To start the services locally, simply run `docker compose up -d`. Or shut them o
     DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
    ```
 
+1. Alternative OAuth Login Option (if you just want to login, without setting up the above providers):
+
+- If the web application is run in `debug` mode, there will be an option called debug login.
+- This feature is <span style="color:red; font-weight: bold">EXPERIMENTAL: use at your own risk, no support provided</span>
+- And do not forget to set `NEXTAUTH_URL` in `.env` to the current website root (example: `NEXTAUTH_URL="http://localhost:3000"`) it will not work otherwise.
+- The Webserver for workspace web needs to be started for it to work, since the OAuth emulation code is in the API
+
 ## Actually running code
 
 - The Project uses [yarn workspaces](https://yarnpkg.com/cli/workspace), which are defined in `/package.json`

--- a/turbo.json
+++ b/turbo.json
@@ -19,7 +19,10 @@
         "FB_CLIENT_ID",
         "FB_CLIENT_SECRET",
         "TWITCH_CLIENT_ID",
-        "TWITCH_CLIENT_SECRET"
+        "TWITCH_CLIENT_SECRET",
+        "NEXTAUTH_URL",
+        "NEXTAUTH_SECRET",
+        "DATABASE_URL"
       ],
       "outputs": ["dist/**", ".next/**", "out/**"]
     },


### PR DESCRIPTION
## **Description**
### A new OAuth login option for Development only, so you do not need to set up External Providers.
- Added an OAuth emulator using typescript to web/api/debug_oauth_emulator.ts
- It is an api endpoint which is only enabled if project is run under `development` mode
- a new Authentication provider for NextAuth to interface with the own OAuth endpoint, also only added in `development` mode
- A new Authentication option is displayed called `experimental_debug_login` if in `development` mode
- You always log in as the same user, so no multi user testing.
- This should simplify project setup, since no external provider is needed
- Also added short documentation to getting-started.md

- Reason for an OAuth emulator is, that a simple email & pass login is not really supported by NextAuth.
I got the flow from oauth2 playground from oauth.com
- This should work, but please verify that it does not get into production
---

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
