### PR TITLE
ci/release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'infrastructure'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+# As this page is updated, make sure to update the appropriate section in the docs
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  # # autolabeler support
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/src/pages/en/working-in-monorepo.md
+++ b/docs/src/pages/en/working-in-monorepo.md
@@ -32,3 +32,9 @@ You should note that unless you have turbo installed globally, you will need to 
 With [yarn workspaces](https://yarnpkg.com/cli/workspace), you are able to run commands in a specific workspaces.
 
 For example, you can add react to the website with `yarn workspace web add react`, or build it alone with `yarn workspace web build`.
+
+## Labeling PRs Effectively
+
+> This section applies to maintainers only
+
+Due to our use of [release-drafter](https://github.com/release-drafter/release-drafter), the way we label PRs is important in automatically building out our releases. In addition to the labels that the auto labeler adds, we have a few more important labels you have to add yourself to PRs. For example, if you are adding a new feature, you should add the `feature` label to the PR. If you are fixing a bug, you should add the `bug` label to the PR, and so on. Furthermore, you **_can_** instruct release-drafter that it needs to increment the major, minor, or patch version by adding the `major`, `minor`, or `patch` label to the PR in addition to the other labels. To better understand what exact labels you should use for a given category of PR, you can look at the [release-drafter config](https://github.com/waldo-vision/waldo/blob/master/.github/release-drafter.yml).


### PR DESCRIPTION
## **Description**

- Add release drafter, a ci tool that automatically builds out our release notes. (We still choose when we want to release.) This just helps us in building more readable release notes as currently its a little hard for the average person to understand them.

## **Issues**

- n/a

---

- [x] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
