### PR TITLE
ci(release): v1 instead of 1 as docker tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,9 @@ jobs:
             ghcr.io/waldo-vision/migrate
           tags: |
             type=schedule,pattern=nightly
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
             type=ref,event=branch
             type=ref,event=pr
             type=sha


### PR DESCRIPTION
## **Description**

- updated formatting of docker tags
	- now `v1` instead of `1`

## **Issues**

n/a

---

- [x] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
