### PR TITLE
Fullscreenable embed on rewiev page & wide monitor min width

### DIFF
--- a/apps/web/pages/submissions/review.tsx
+++ b/apps/web/pages/submissions/review.tsx
@@ -209,6 +209,7 @@ export default function Review() {
                         justifyContent={'center'}
                         fontSize={18}
                         ml={2}
+                        minWidth={'42vw'}
                       >
                         <Flex direction={'row'} gap={2}>
                           <Text>
@@ -247,6 +248,7 @@ export default function Review() {
                           width: '100%',
                           height: '42vh',
                         }}
+                        allowFullScreen={true}
                       />
                     )}
                   </Box>


### PR DESCRIPTION
## **Description**
- add allowfullscreen tag to youtube embed on review page
- add minimal width for embed, to mitigate issues on wide screens (should not break mobile, since only minimal widht)

## **Issues**

- Fixes this: [Big Monitor Issue](https://github.com/waldo-vision/waldo/issues/228)

---

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
