### PR TITLE
docs: update local dev server README

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -33,5 +33,5 @@ NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=example
 DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable" # <- self hosted example
 
 # next auth
-NEXTAUTH_URL=http://localhost:3000 # <- self hosted example
+NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=example

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,6 @@
-# make sure to update the turbo.json
+# make sure to update the turbo.json when adding new variables
 
+# Discord
 DISCORD_CLIENT_ID=example
 DISCORD_CLIENT_SECRET=example
 
@@ -8,15 +9,19 @@ GOOGLE_CLIENT_ID=example
 GOOGLE_CLIENT_SECRET=example
 YOUTUBE_API_KEY=example
 
+# GitHub
 GITHUB_CLIENT_ID=example
 GITHUB_CLIENT_SECRET=example
 
+# Battle.net
 BTLNET_CLIENT_ID=example
 BTLNET_CLIENT_SECRET=example
 
+# Twitch
 TWITCH_CLIENT_ID=example
 TWITCH_CLIENT_SECRET=example
 
+# Facebook
 FB_CLIENT_ID=example
 FB_CLIENT_SECRET=example
 
@@ -25,8 +30,8 @@ CLOUDFLARE_TURNSTILE_SECRET=example
 NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=example
 
 # database
-DATABASE_URL=example
+DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable" # <- self hosted example
 
 # next auth
-NEXTAUTH_URL=example
+NEXTAUTH_URL=http://localhost:3000 # <- self hosted example
 NEXTAUTH_SECRET=example

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,6 +6,14 @@ This is the monolithic NextJS app deployed at https://waldo.vision.
 
 The app can be run as a local server for ease of development. This process is fairly straightforward.
 
+### Install Dependencies
+
+Install all JS dependencies with yarn:
+
+```bash
+yarn install
+```
+
 ### Configuration
 
 The frontend is configured through via environment variables stored a `.env` file in this directory.
@@ -75,9 +83,9 @@ Alternatively, you can use CockroachDB's free [serverless tier](https://www.cock
 You will now need to set the `DATABASE_URL` variable in two configuration files:
 
 - `apps/web/.env`
-- `packages/database/.env`
+- `packages/database/.env`. If you haven't already, create this file with `cp packages/database/.env.example packages/database/.env`.
 
-If self-hosting using the docker-compose method, then set `DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"`.
+If self-hosting using the docker-compose method, then set `DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"` in each of these files.
 
 #### Migration
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -32,78 +32,30 @@ cp apps/web/.env.example apps/web/.env
 vim apps/web/.env
 ```
 
-Then configure the variables in this file.
-
-#### Discord
-
-If you plan on authenticating to Discord, make sure these credentials are set.
-
-- `DISCORD_CLIENT_ID`
-- `DISCORD_CLIENT_SECRET`
-
-Follow [this guide](https://discordjs.guide/oauth2/#getting-an-oauth2-url) until you have added the `Redirect URL`. Be sure to set this to `http://localhost:3000/api/auth/callback/discord`.
-
-#### GitHub
-
-If you plan on authenticating to GitHub, make sure these credentials are set.
-
-- `GITHUB_CLIENT_ID`
-- `GITHUB_CLIENT_SECRET`
-
-Follow [this guide](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app). Be sure to set the `Callback URL` to `http://localhost:3000/api/auth/callback/github`.
-
-#### Next Auth
-
-Be sure to also set the `NEXTAUTH_URL` variable.
-
-- `NEXTAUTH_URL=http://localhost:3000`.
-
-#### CloudFlare Turnstile
-
-_TODO: add CloudFlare configuration docs_
-
-#### Youtube
-
-_TODO: add Youtube configuration docs_
-
-### CockroachDB
-
-The primary database used by the app is CockroachDB. You will need a working server to run this app locally.
-
-#### Hosting
-
-You can easily spin up a new CockroachDB container with the `docker-compose` file at the root of this repo.
-
-```bash
-docker-compose up -d
-
-# Check that the server is running
-docker ps
-```
-
-Alternatively, you can use CockroachDB's free [serverless tier](https://www.cockroachlabs.com/get-started-cockroachdb/) if you don't wish to self-host.
-
-#### Configuration
-
-You will now need to set the `DATABASE_URL` variable in two configuration files:
-
-- `apps/web/.env`
-- `packages/database/.env`. If you haven't already, create this file with `cp packages/database/.env.example packages/database/.env`.
-
-If self-hosting using the docker-compose method, then set `DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"` in each of these files.
-
-#### Migration
-
-With your configuration set, you should be ready to run the migrations needed for our ORM to work.
-
-```bash
-yarn turbo db:generate
-yarn turbo run db:push
-```
+| Variable                                  | Description                                                | Link                                                                                         |
+| :---------------------------------------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------- |
+| DISCORD_CLIENT_ID                         | Discord OAuth client ID                                    | [docs](https://discordjs.guide/oauth2/#getting-an-oauth2-url)                                |
+| DISCORD_CLIENT_SECRET                     | Discord OAuth client secret                                |                                                                                              |
+| GOOGLE_CLIENT_ID                          | ...                                                        |                                                                                              |
+| GOOGLE_CLIENT_SECRET                      | ...                                                        |                                                                                              |
+| YOUTUBE_API_KEY                           | ...                                                        |                                                                                              |
+| GITHUB_CLIENT_ID                          | GitHub OAuth client ID                                     | [docs](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) |
+| GITHUB_CLIENT_SECRET                      | GitHub OAuth client secret                                 |                                                                                              |
+| BTLNET_CLIENT_ID                          | ...                                                        |                                                                                              |
+| BTLNET_CLIENT_SECRET                      | ...                                                        |                                                                                              |
+| TWITCH_CLIENT_ID                          | ...                                                        |                                                                                              |
+| TWITCH_CLIENT_SECRET                      | ...                                                        |                                                                                              |
+| FB_CLIENT_ID                              | ...                                                        |                                                                                              |
+| FB_CLIENT_SECRET                          | ...                                                        |                                                                                              |
+| CLOUDFLARE_TURNSTILE_SECRET               | ...                                                        |                                                                                              |
+| NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY | ...                                                        |                                                                                              |
+| DATABASE_URL                              | Postgres connection string used to connect to CockroachDB. |                                                                                              |
+| NEXTAUTH_URL                              | ...                                                        |                                                                                              |
+| NEXTAUTH_SECRET                           | ...                                                        |                                                                                              |
 
 ### Starting the server
 
-With your environment configured, you should be ready to start the dev server.
+If you have not already, then follow the [set-up documentation](https://docs.waldo.vision/en/getting-started).
 
 ```bash
 yarn workspace web dev

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,11 +4,16 @@ This is the monolithic NextJS app deployed at https://waldo.vision.
 
 ## Getting Started
 
-The app can be run as a local server for ease of development. This process is fairly straightforward.
+The easiest way to get started with Waldo is to build and run the app locally. This process is fairly straight forward.
 
 ### Install Dependencies
 
-Install all JS dependencies with yarn:
+You'll need to install a few dependencies in order to run the dev server:
+
+- [yarn](https://yarnpkg.com/getting-started/install) - our JavaScript package manager.
+- [docker](https://docs.docker.com/engine/install/) - used for building and running containers.
+
+With those installed, you can download additional packages with yarn:
 
 ```bash
 yarn install
@@ -16,9 +21,9 @@ yarn install
 
 ### Configuration
 
-The frontend is configured through via environment variables stored a `.env` file in this directory.
+The app is configured via environment variables stored within a `.env` file in this directory.
 
-Start by copying the the example file env file.
+Start by copying the example env file.
 
 ```bash
 cp apps/web/.env.example apps/web/.env
@@ -27,7 +32,7 @@ cp apps/web/.env.example apps/web/.env
 vim apps/web/.env
 ```
 
-Then configure the variables in this file. There are a few sections to note.
+Then configure the variables in this file.
 
 #### Discord
 
@@ -113,3 +118,5 @@ yarn workspace web build
 # Serve the app
 yarn workspace web start
 ```
+
+You should now be able to visit the website at http://localhost:3000.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,34 +1,107 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# WALDO App
+
+This is the monolithic NextJS app deployed at https://waldo.vision.
 
 ## Getting Started
 
-First, run the development server:
+The app can be run as a local server for ease of development. This process is fairly straightforward.
+
+### Configuration
+
+The frontend is configured through via environment variables stored a `.env` file in this directory.
+
+Start by copying the the example file env file.
 
 ```bash
-npm run dev
-# or
-yarn dev
+cp apps/web/.env.example apps/web/.env
+
+# Open the file
+vim apps/web/.env
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Then configure the variables in this file. There are a few sections to note.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+#### Discord
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+If you plan on authenticating to Discord, make sure these credentials are set.
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+- `DISCORD_CLIENT_ID`
+- `DISCORD_CLIENT_SECRET`
 
-## Learn More
+Follow [this guide](https://discordjs.guide/oauth2/#getting-an-oauth2-url) until you have added the `Redirect URL`. Be sure to set this to `http://localhost:3000/api/auth/callback/discord`.
 
-To learn more about Next.js, take a look at the following resources:
+#### GitHub
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+If you plan on authenticating to GitHub, make sure these credentials are set.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET`
 
-## Deploy on Vercel
+Follow [this guide](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app). Be sure to set the `Callback URL` to `http://localhost:3000/api/auth/callback/github`.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+#### Next Auth
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+Be sure to also set the `NEXTAUTH_URL` variable.
+
+- `NEXTAUTH_URL=http://localhost:3000`.
+
+#### CloudFlare Turnstile
+
+_TODO: add CloudFlare configuration docs_
+
+#### Youtube
+
+_TODO: add Youtube configuration docs_
+
+### CockroachDB
+
+The primary database used by the app is CockroachDB. You will need a working server to run this app locally.
+
+#### Hosting
+
+You can easily spin up a new CockroachDB container with the `docker-compose` file at the root of this repo.
+
+```bash
+docker-compose up -d
+
+# Check that the server is running
+docker ps
+```
+
+Alternatively, you can use CockroachDB's free [serverless tier](https://www.cockroachlabs.com/get-started-cockroachdb/) if you don't wish to self-host.
+
+#### Configuration
+
+You will now need to set the `DATABASE_URL` variable in two configuration files:
+
+- `apps/web/.env`
+- `packages/database/.env`
+
+If self-hosting using the docker-compose method, then set `DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"`.
+
+#### Migration
+
+With your configuration set, you should be ready to run the migrations needed for our ORM to work.
+
+```bash
+yarn turbo db:generate
+yarn turbo run db:push
+```
+
+### Starting the server
+
+With your environment configured, you should be ready to start the dev server.
+
+```bash
+yarn workspace web dev
+```
+
+Alternatively, you can build an optimized deployment of the app and deploy that instead.
+
+```bash
+# Build the app
+yarn workspace web build
+
+# Serve the app
+yarn workspace web start
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       # ui
       - 8081:8080
     volumes:
-      - './docker/cockroach/data:/cockroach/cockroach-data:z'
+      - './docker/cockroach/data:/cockroach/cockroach-data:Z'
     ulimits:
       nofile: 2048
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
       # ui
       - 8081:8080
     volumes:
-      - './docker/cockroach/data:/cockroach/cockroach-data'
+      - './docker/cockroach/data:/cockroach/cockroach-data:z'
+    ulimits:
+      nofile: 2048
 
   redis:
     image: redis

--- a/docs/src/pages/en/getting-started.md
+++ b/docs/src/pages/en/getting-started.md
@@ -64,6 +64,12 @@ To start the services locally, simply run `docker compose up -d`. Or shut them o
 
    (This is if you're self hosting, if you're using CockroachDB cloud, copy the connection URL from the dashboard.)
 
+1. There is additional `.env` file in `packages/database`. The database url should be the same as above.
+
+   ```.env
+    DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
+   ```
+
 1. Run `yarn turbo run db:push` to setup the database for the website.
 
 1. Additionally, you may also want to set the `Cloudflare Turnstile` keys so that submissions work, or the `Youtube API Key` so that the review site works properly.
@@ -83,12 +89,6 @@ To start the services locally, simply run `docker compose up -d`. Or shut them o
     DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
 
     # plus some other stuff if you set it
-   ```
-
-1. There is additional `.env` file in `packages/database`. The database url should be the same as above.
-
-   ```.env
-    DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
    ```
 
 ## Actually running code

--- a/docs/src/pages/en/getting-started.md
+++ b/docs/src/pages/en/getting-started.md
@@ -104,17 +104,17 @@ The primary database used by the app is CockroachDB. You will need a working ser
 
 #### Hosting
 
-You can easily spin up a new CockroachDB container with the `docker-compose` file at the root of this repo.
+You can easily spin up a new CockroachDB container with the `docker compose` file at the root of this repo.
 
 ```bash
 # start the container
-docker-compose up -d
+docker compose up -d
 
 # Check that the container is running
 docker ps
 
 # If at any point you wish to shut down the container:
-docker-compose down
+docker compose down
 ```
 
 Alternatively, you can use CockroachDB's free [serverless tier](https://www.cockroachlabs.com/get-started-cockroachdb/) if you don't wish to self-host.
@@ -135,7 +135,7 @@ You will now need to set the `DATABASE_URL` variable in two configuration files:
 - `apps/web/.env`
 - `packages/database/.env`. If you haven't already, create this file with `cp packages/database/.env.example packages/database/.env`.
 
-If self-hosting using the docker-compose method, then you can set your variable like so:
+If self-hosting using the `docker compose` method, then you can set your variable like so:
 
 ```bash
 DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"

--- a/docs/src/pages/en/getting-started.md
+++ b/docs/src/pages/en/getting-started.md
@@ -16,88 +16,169 @@ Before you can start hacking away on waldo, you need to have the tools below to 
 
 Waldo Vision is dependent on a number of services, and depending on your needs, you can either self host, or use a cloud option for all of them. We recommend you self host for ease of development, but the cloud options do exist if you wish to use them.
 
-### Cloud Options
+## Setting Up A Local Deployment
 
-#### CockroachDB
+First, clone the git repo `https://github.com/waldo-vision/waldo` to your machine then navigate to it using the 'cd' console command.
 
-If you don't wish to self host CockroachDB for development, we advise you use CockroachDB's free [serverless tier](https://www.cockroachlabs.com/get-started-cockroachdb/) during development.
+### Install Dependencies
 
-### Self Hosting
+You'll need to install a few dependencies in order to run the dev server:
 
-If you feel comfortable self hosting, for our use case, you we require that you additionally install [Docker](https://www.docker.com/) and [Docker compose](https://docs.docker.com/compose/). Docker is used to help ensure that the services are setup consistantly setup accross all our contributors' machines. (If you want to use podman instead of docker, you can, but we will not provide assistance with it.)
+- [yarn](https://yarnpkg.com/getting-started/install) - our JavaScript package manager.
+- [docker](https://docs.docker.com/engine/install/) - used for building and running containers.
 
-To start the services locally, simply run `docker compose up -d`. Or shut them off with `docker compose down`. (Run these in the repo after you have cloned it.)
+With those installed, you can download additional packages with yarn:
 
-- Option for Windows Users:
-  - <span style="color:red; font-weight: bold">WARNING: Not recommended for development, use at your own risk, no support provided</span>.
-  - For Windows you can download the Beta Archive from [Cockroachlabs](https://www.cockroachlabs.com/docs/stable/install-cockroachdb-windows.html)
-    and run the exe with `./cockroach.exe start-single-node --insecure`
-  - Then set the `DATABASE_URL` variable in `/packages/database/.env` and `/packages/web/.env` to the url displayed on start for postgresql
-  - You even have a Web interface for management and debugging
-  - WARNING BETA: (From their site: The CockroachDB executable for Windows is experimental and not suitable for production deployments. Windows 8 or higher is required.)
+```bash
+yarn install
+```
 
-## Setting Up Code
+### Configuration
 
-1. Clone the git repo `https://github.com/waldo-vision/waldo` to your machine then navigate to it using the 'cd' console command.
-1. Run `yarn install` to install all the necessary dependencies.
-1. To setup our ORM, run `yarn turbo db:generate`.
-1. Now, you need to choose whether you want to login with Discord, or Github.
-   - If you choose Github, follow [this guide](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app). Be sure to set the `Callback URL` to `http://localhost:3000/api/auth/callback/github`.
-   - If you choose Discord, follow [this guide](https://discordjs.guide/oauth2/#getting-an-oauth2-url) until you have added the `Redirect URL`. Be sure to set this to `http://localhost:3000/api/auth/callback/discord`.
-1. Copy `apps/web/.env.example` and rename said copy to `apps/web/.env`.
+The app is configured via environment variables stored within a `.env` file in this directory.
 
-   - Take the `client id` and `client secret` from the above to fill in the fields in the .env file like so:
+Start by copying the example env file.
 
-   ```.env
-    DISCORD_CLIENT_ID="57324592435671234019234"
-    DISCORD_CLIENT_SECRET="342759ASDa82dsaf345-ADHFUFA"
+```bash
+cp apps/web/.env.example apps/web/.env
 
-    GITHUB_CLIENT_ID="7482521243341245243"
-    GITHUB_CLIENT_SECRET="FDGNJO3490TNGFMGDSK"
-   ```
+# Open the file
+vim apps/web/.env
+```
 
-1. To connect to the database, in the `.env` file set the `DATABASE_URL` like below:
+#### Discord
 
-   ```.env
-    DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
-   ```
+If you plan on authenticating to Discord, make sure these credentials are set.
 
-   (This is if you're self hosting, if you're using CockroachDB cloud, copy the connection URL from the dashboard.)
+- `DISCORD_CLIENT_ID`
+- `DISCORD_CLIENT_SECRET`
 
-1. There is additional `.env` file in `packages/database`. The database url should be the same as above.
+Follow [this guide](https://discordjs.guide/oauth2/#getting-an-oauth2-url) until you have added the `Redirect URL`. Be sure to set this to `http://localhost:3000/api/auth/callback/discord`.
 
-   ```.env
-    DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
-   ```
+Update your .env file like so:
 
-1. Run `yarn turbo run db:push` to setup the database for the website.
+```.env
+DISCORD_CLIENT_ID="57324592435671234019234"
+DISCORD_CLIENT_SECRET="342759ASDa82dsaf345-ADHFUFA"
+```
 
-1. Additionally, you may also want to set the `Cloudflare Turnstile` keys so that submissions work, or the `Youtube API Key` so that the review site works properly.
+#### GitHub
 
-   - Currently there is no guide for these items, but there isn't much to setting them up. The only item of note is that the YT API Key needs to be `version 3` of the api.
-   - If you do not wish to setup a cloudflare site to be able to generate turnstile keys, you can use the demo site and secret keys which you can find here: https://developers.cloudflare.com/turnstile/frequently-asked-questions/#are-there-sitekeys-and-secret-keys-that-can-be-used-for-testing.
+If you plan on authenticating to GitHub, make sure these credentials are set.
 
-1. The finale `.env` file _might_ look a little something like this after everything is filled in:
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET`
 
-   ```.env
-    DISCORD_CLIENT_ID="57324592435671234019234"
-    DISCORD_CLIENT_SECRET="342759ASDa82dsaf345-ADHFUFA"
+Follow [this guide](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app). Be sure to set the `Callback URL` to `http://localhost:3000/api/auth/callback/github`.
 
-    GITHUB_CLIENT_ID="7482521243341245243"
-    GITHUB_CLIENT_SECRET="FDGNJO3490TNGFMGDSK"
+Update your .env file like so:
 
-    DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
+```.env
+GITHUB_CLIENT_ID="7482521243341245243"
+GITHUB_CLIENT_SECRET="FDGNJO3490TNGFMGDSK"
+```
 
-    # plus some other stuff if you set it
-   ```
+#### Next Auth
 
-## Actually running code
+Be sure to also set the `NEXTAUTH_URL` variable.
 
-- The Project uses [yarn workspaces](https://yarnpkg.com/cli/workspace), which are defined in `/package.json`
-- Each submodule (database/webfrontend/webbackend/desktop app) defines its own `package.json` which is then used by yarn to run commands on it
-- For example running the webfrontend can be done with: `yarn workspace web start`
-- Usually it spins up a webserver at some localhost port, which is displayed in the command line
-- Additional info about the monorepo can be found at [Working in the monorepo](/en/working-in-monorepo)
+- `NEXTAUTH_URL=http://localhost:3000`.
+
+#### CloudFlare Turnstile
+
+_TODO: add CloudFlare configuration docs_
+
+You may also want to set the `Cloudflare Turnstile` keys so that submissions work.
+
+#### Youtube
+
+_TODO: add Youtube configuration docs_
+
+You may also want to set the `Youtube API Key` so that the review site works properly.
+
+_Note: YT API Key needs to be `version 3` of the api._
+
+### CockroachDB
+
+The primary database used by the app is CockroachDB. You will need a working server to run this app locally.
+
+#### Hosting
+
+You can easily spin up a new CockroachDB container with the `docker-compose` file at the root of this repo.
+
+```bash
+# start the container
+docker-compose up -d
+
+# Check that the container is running
+docker ps
+
+# If at any point you wish to shut down the container:
+docker-compose down
+```
+
+Alternatively, you can use CockroachDB's free [serverless tier](https://www.cockroachlabs.com/get-started-cockroachdb/) if you don't wish to self-host.
+
+Option for Windows Users:
+
+- <span style="color:red; font-weight: bold">WARNING: Not recommended for development, use at your own risk, no support provided</span>.
+- For Windows you can download the Beta Archive from [Cockroachlabs](https://www.cockroachlabs.com/docs/stable/install-cockroachdb-windows.html)
+  and run the exe with `./cockroach.exe start-single-node --insecure`
+- Then set the `DATABASE_URL` variable in `/packages/database/.env` and `/packages/web/.env` to the url displayed on start for postgresql
+- You even have a Web interface for management and debugging
+- WARNING BETA: (From their site: The CockroachDB executable for Windows is experimental and not suitable for production deployments. Windows 8 or higher is required.)
+
+#### Configuration
+
+You will now need to set the `DATABASE_URL` variable in two configuration files:
+
+- `apps/web/.env`
+- `packages/database/.env`. If you haven't already, create this file with `cp packages/database/.env.example packages/database/.env`.
+
+If self-hosting using the docker-compose method, then you can set your variable like so:
+
+```bash
+DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable"
+```
+
+#### Migration
+
+With your configuration set, you should be ready to run the migrations needed for our ORM to work.
+
+```bash
+yarn turbo db:generate
+yarn turbo run db:push
+```
+
+### Starting the server
+
+With your environment configured, you should be ready to start the dev server.
+
+```bash
+yarn workspace web dev
+```
+
+Alternatively, you can build an optimized deployment of the app and deploy that instead.
+
+```bash
+# Build the app
+yarn workspace web build
+
+# Serve the app
+yarn workspace web start
+```
+
+You should now be able to visit the website at http://localhost:3000.
+
+## Additional notes
+
+### Workspaces
+
+The Project uses [yarn workspaces](https://yarnpkg.com/cli/workspace), which are defined in `/package.json`.
+
+Each submodule (database/webfrontend/webbackend/desktop app) defines its own `package.json` which is then used by yarn to run commands on it.
+
+For example, running the webfrontend can be done with: `yarn workspace web start`.
 
 ## Picking work
 

--- a/packages/database/.env.example
+++ b/packages/database/.env.example
@@ -4,4 +4,5 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL=example
+# Database
+DATABASE_URL="postgresql://root@localhost:26257?sslmode=disable" # <- self hosted example


### PR DESCRIPTION
## **Description**

- Updated `apps/web/README.md` to have up-to-date description of the monolith app.  See the new README [here](https://github.com/waldo-vision/waldo/tree/fix/update-web-docs/apps/web). Also updated the getting started instructions in the docs website.
- Made a couple of tweaks to `docker-compose.yml` to fix a couple of issues I ran into while starting the containers with SELinux enabled. 

## **Issues**

- N/A

---

- [x] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
