### PR TITLE
Added simple OpenGraph tags to main site for better embeds on link sharing

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -52,6 +52,16 @@ export default function Home() {
           name="description"
           content="Waldo Vision is an open-source visual cheat detection project, powered by deep learning"
         />
+        {/*Open Graph Protocol headers (for custom embeds)*/}
+        <meta property="og:title" content="Waldo Vision | AI Anticheat" />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content="https://waldo.vision/InScans.png" />
+        <meta property="og:url" content="https://waldo.vision/" />
+        <meta property="og:site_name" content="Waldo Vision" />
+        <meta
+          property="og:description"
+          content="Open-source visual cheat detection, powered by deep learning"
+        />
       </Head>
 
       <Flex direction={'column'} mb={150}>


### PR DESCRIPTION
## **Description**
- added open graph tags as requested by #99 
- this should produce better embeds when https://waldo.vision is shared on Discord etc.
- Issue #99 is not resolved with this, since only index page gets better embed (Idea: Share Buttons on site?)

## **Issues**
- #99 
---

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
