### PR TITLE
Added forced game selection for video submission

### DIFF
--- a/apps/web/pages/submissions/upload.tsx
+++ b/apps/web/pages/submissions/upload.tsx
@@ -51,7 +51,7 @@ export default function Upload() {
   const [tsToken, setTsToken] = useState<string | undefined>('');
   const [requestDone, setRequestDone] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
-  const [selectedGame, setSelectedGame] = useState<string | null>(null);
+  const [selectedGame, setSelectedGame] = useState<string>('');
   const [cheats, setCheats] = useState<Cheat[]>([]);
   const [legalConfirmations, setLegalConfirmations] = useState<number>(0);
 
@@ -165,8 +165,9 @@ export default function Upload() {
       handleRequestError('Please check the required legal agreement options.');
       return;
     }
-    if (selectedGame == null) {
+    if (selectedGame === '') {
       handleRequestError('Please select a game.');
+      setCurrentUrl(currentUrl); //prevent link from being cleared
       return;
     }
     type Input = inferProcedureInput<AppRouter['gameplay']['create']>;

--- a/apps/web/pages/submissions/upload.tsx
+++ b/apps/web/pages/submissions/upload.tsx
@@ -51,7 +51,7 @@ export default function Upload() {
   const [tsToken, setTsToken] = useState<string | undefined>('');
   const [requestDone, setRequestDone] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
-  const [selectedGame, setSelectedGame] = useState<string>('csg');
+  const [selectedGame, setSelectedGame] = useState<string | null>(null);
   const [cheats, setCheats] = useState<Cheat[]>([]);
   const [legalConfirmations, setLegalConfirmations] = useState<number>(0);
 
@@ -163,6 +163,10 @@ export default function Upload() {
 
     if (legalConfirmations != 3) {
       handleRequestError('Please check the required legal agreement options.');
+      return;
+    }
+    if (selectedGame == null) {
+      handleRequestError('Please select a game.');
       return;
     }
     type Input = inferProcedureInput<AppRouter['gameplay']['create']>;


### PR DESCRIPTION
## **Description**
- add forced game selection, by setting initial game to null
- if game is null on submission, error message is displayed
- null in select game list makes it display the "Select a game prompt"
- selectedGame is not read otherwise, so no weird null exceptions this time
## **Issues**
- #229 
---

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
