### PR TITLE
Removed double import for sentry to fix failing build

### DIFF
--- a/apps/web/server/trpc/router/gameplay.ts
+++ b/apps/web/server/trpc/router/gameplay.ts
@@ -11,7 +11,6 @@ import { z } from 'zod';
 import { vUser } from './util';
 import { router, protectedProcedure } from '../trpc';
 import { SegmentSchema } from '@utils/zod/segment';
-import * as Sentry from '@sentry/nextjs';
 import { hasPerms, Perms } from '@server/utils/hasPerms';
 import { serverSanitize } from '@utils/sanitize';
 import * as Sentry from '@sentry/nextjs';


### PR DESCRIPTION
## **Description**
- remove a double import failing the build

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
