### PR TITLE
Removed OpenAPI endpoint for private APIs

### DIFF
--- a/apps/web/server/trpc/router/apikeys.ts
+++ b/apps/web/server/trpc/router/apikeys.ts
@@ -9,7 +9,6 @@ import { ApiKeyState } from 'database';
 import * as Sentry from '@sentry/nextjs';
 export const apiKeyRouter = router({
   get: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/api/key' } })
     .input(
       z.object({
         keyId: z.string().cuid(),
@@ -49,7 +48,6 @@ export const apiKeyRouter = router({
       }
     }),
   getUserApiKeys: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/api/key/user' } })
     .input(
       z.object({
         userId: z.string().cuid(),
@@ -91,7 +89,6 @@ export const apiKeyRouter = router({
       }
     }),
   create: protectedProcedure
-    .meta({ openapi: { method: 'POST', path: '/api/key' } })
     .input(
       z.object({
         userId: z.string().cuid(),
@@ -144,7 +141,6 @@ export const apiKeyRouter = router({
       }
     }),
   delete: protectedProcedure
-    .meta({ openapi: { method: 'DELETE', path: '/api/key' } })
     .input(
       z.object({
         id: z.string().cuid(),

--- a/apps/web/server/trpc/router/clip.ts
+++ b/apps/web/server/trpc/router/clip.ts
@@ -8,7 +8,6 @@ import { serverSanitize } from '@utils/sanitize';
 import * as Sentry from '@sentry/nextjs';
 export const clipRouter = router({
   get: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/clip' } })
     .input(
       z
         .object({
@@ -62,7 +61,6 @@ export const clipRouter = router({
       }
     }),
   delete: protectedProcedure
-    .meta({ openapi: { method: 'DELETE', path: '/clip' } })
     .input(
       z
         .object({
@@ -111,7 +109,6 @@ export const clipRouter = router({
       }
     }),
   create: protectedProcedure
-    .meta({ openapi: { method: 'POST', path: '/clip' } })
     .input(
       z
         .object({

--- a/apps/web/server/trpc/router/gameplay.ts
+++ b/apps/web/server/trpc/router/gameplay.ts
@@ -19,7 +19,6 @@ export const gameplayRouter = router({
    * Get a specific gameplay
    */
   get: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/gameplay' } })
     .input(
       z
         .object({
@@ -63,7 +62,6 @@ export const gameplayRouter = router({
    * Admin API
    */
   getMany: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/gameplay/dash' } })
     .input(
       z.object({
         page: z.number(),
@@ -143,7 +141,6 @@ export const gameplayRouter = router({
    * Create a new gameplay
    */
   create: protectedProcedure
-    .meta({ openapi: { method: 'POST', path: '/gameplay' } })
     .input(
       z.object({
         youtubeUrl: z.string().url(),
@@ -233,7 +230,6 @@ export const gameplayRouter = router({
    * Get gameplay submitted by a user
    */
   getUsers: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/gameplay/user' } })
     .input(
       z
         .object({
@@ -287,7 +283,6 @@ export const gameplayRouter = router({
       return user.gameplay;
     }),
   getClips: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/gameplay/clips' } })
     .input(
       z
         .object({
@@ -333,7 +328,6 @@ export const gameplayRouter = router({
       return gameplay.clips;
     }),
   update: protectedProcedure
-    .meta({ openapi: { method: 'PATCH', path: '/gameplay' } })
     .input(
       z
         .object({
@@ -402,7 +396,6 @@ export const gameplayRouter = router({
       }
     }),
   delete: protectedProcedure
-    .meta({ openapi: { method: 'DELETE', path: '/gameplay' } })
     .input(
       z
         .object({
@@ -462,7 +455,6 @@ export const gameplayRouter = router({
       }
     }),
   getReviewItems: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/gameplay/review' } })
     .input(
       z.object({
         tsToken: z.string(),
@@ -533,7 +525,6 @@ export const gameplayRouter = router({
       }
     }),
   review: protectedProcedure
-    .meta({ openapi: { method: 'PATCH', path: '/gameplay/review' } })
     .input(
       z.object({
         gameplayId: z.string().cuid(),

--- a/apps/web/server/trpc/router/site.ts
+++ b/apps/web/server/trpc/router/site.ts
@@ -81,7 +81,6 @@ export const siteRouter = router({
       return siteData;
     }),
   updatePage: protectedProcedure
-    .meta({ openapi: { method: 'POST', path: '/site/page' } })
     .input(
       z
         .object({
@@ -144,7 +143,6 @@ export const siteRouter = router({
       };
     }),
   updateSite: protectedProcedure
-    .meta({ openapi: { method: 'POST', path: '/site/site' } })
     .input(
       z
         .object({

--- a/apps/web/server/trpc/router/site.ts
+++ b/apps/web/server/trpc/router/site.ts
@@ -7,7 +7,6 @@ import * as Sentry from '@sentry/nextjs';
 
 export const siteRouter = router({
   getPageData: publicProcedure
-    .meta({ openapi: { method: 'GET', path: '/site/page' } })
     .input(
       z
         .object({
@@ -45,7 +44,6 @@ export const siteRouter = router({
       return pageData;
     }),
   getSiteData: publicProcedure
-    .meta({ openapi: { method: 'GET', path: '/site/site' } })
     .input(
       z
         .object({

--- a/apps/web/server/trpc/router/user.ts
+++ b/apps/web/server/trpc/router/user.ts
@@ -8,7 +8,6 @@ import { serverSanitize } from '@utils/sanitize';
 import * as Sentry from '@sentry/nextjs';
 export const userRouter = router({
   blackList: protectedProcedure
-    .meta({ openapi: { method: 'PUT', path: '/user' } })
     .input(
       z
         .object({
@@ -60,7 +59,6 @@ export const userRouter = router({
       }
     }),
   delete: protectedProcedure
-    .meta({ openapi: { method: 'DELETE', path: '/user' } })
     .input(
       z
         .object({
@@ -109,7 +107,6 @@ export const userRouter = router({
       }
     }),
   getLinkedAccounts: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/user/linkedaccounts' } })
     .input(z.void())
     .output(
       z.array(
@@ -141,7 +138,6 @@ export const userRouter = router({
       }
     }),
   unlinkAccount: protectedProcedure
-    .meta({ openapi: { method: 'DELETE', path: '/user/linkedaccounts' } })
     .input(
       z
         .object({
@@ -199,7 +195,6 @@ export const userRouter = router({
       }
     }),
   getUsers: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/user/dash' } })
     .input(
       z
         .object({
@@ -281,7 +276,6 @@ export const userRouter = router({
       }
     }),
   updateRole: protectedProcedure
-    .meta({ openapi: { method: 'PATCH', path: '/user/dash' } })
     .input(
       z
         .object({
@@ -327,7 +321,6 @@ export const userRouter = router({
       }
     }),
   search: protectedProcedure
-    .meta({ openapi: { method: 'GET', path: '/user/search' } })
     .input(
       z
         .object({

--- a/apps/web/server/trpc/router/util.ts
+++ b/apps/web/server/trpc/router/util.ts
@@ -48,7 +48,6 @@ export async function vUser(tsToken: string) {
 
 export const utilRouter = router({
   verifyUser: protectedProcedure
-    .meta({ openapi: { method: 'PUT', path: '/user/verify' } })
     .input(
       z
         .object({


### PR DESCRIPTION
## **Description**
- removed OpenAPI endpoints for private apis to reduce issues with OpenAPI and zod types not working together
(If you do not specify a meta tag, openapi will not parse that endpoint, and therefore will not throw errors, if it does not understand the zod types)
- Left in OpenApi endpoints for site status(/api/site/site, /api/site/page) (since those are public and may be used for monitoring scripts) and python script
- OpenAPI is only needed for public apis (python analysis script)
---

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
