### PR TITLE
Added yarn branch shortcut to fix branching version mismatches

### DIFF
--- a/docs/src/pages/en/getting-started.md
+++ b/docs/src/pages/en/getting-started.md
@@ -180,6 +180,23 @@ Each submodule (database/webfrontend/webbackend/desktop app) defines its own `pa
 
 For example, running the webfrontend can be done with: `yarn workspace web start`.
 
+### Switching git branches
+
+If you checkout git branches/commits you may encounter different versions of the database & packages. This may mean, that your build won't compile, since the generated files are outdated.
+To fix it, run
+
+```bash
+yarn branch
+```
+
+which is just a fancy shortcut for (if you need to fix command failure):
+
+```bash
+yarn install #install dependencies
+yarn turbo db:generate #generate new db model
+yarn turbo run db:push #deploy the current db model to dev database
+```
+
 ## Picking work
 
 > Please follow the GitHub Projects, Milestones, and Issues:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "turbo run build",
     "lint": "turbo run lint",
     "format": "prettier --write \"{apps,packages,docs}/**/*.{ts,tsx,md,json}\"",
-    "format-check": "prettier --check \"{apps,packages,docs}/**/*.{ts,tsx,md,json}\""
+    "format-check": "prettier --check \"{apps,packages,docs}/**/*.{ts,tsx,md,json}\"",
+    "branch": "yarn install && yarn turbo db:generate && yarn turbo db:push"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.59.0",


### PR DESCRIPTION
## **Description**
- Added a shortcut for yarn that installs deps, updates db schema and pushes to database
- should make checking out branches easier: just run `yarn branch` when doing a git checkout
- Added to docs
---

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
