### PR TITLE
Removed API link for USER role in Account page & Trusted can now create API keys

### DIFF
--- a/apps/web/pages/account.tsx
+++ b/apps/web/pages/account.tsx
@@ -267,30 +267,36 @@ export default function Account() {
                                       {name.toLowerCase()} account.
                                     </Text>
                                   </Flex>
-                                  <Flex direction={'column'}>
-                                    <Divider my={5} />
-                                    <Text fontWeight={'bold'}>API Access</Text>
-                                    <Text
-                                      fontWeight={'regular'}
-                                      mb={5}
-                                      fontSize={15}
-                                      _hover={{ textDecoration: 'underline' }}
-                                      cursor={'pointer'}
-                                      onClick={() =>
-                                        router.push(
-                                          '/portal/developers/apikeys',
-                                        )
-                                      }
-                                    >
-                                      <chakra.span
-                                        fontWeight={'bold'}
-                                        textColor={'purple.500'}
+                                  {session?.user?.role !== 'USER' ? (
+                                    <Flex direction={'column'}>
+                                      <Divider my={5} />
+                                      <Text fontWeight={'bold'}>
+                                        API Access
+                                      </Text>
+                                      <Text
+                                        fontWeight={'regular'}
+                                        mb={5}
+                                        fontSize={15}
+                                        _hover={{ textDecoration: 'underline' }}
+                                        cursor={'pointer'}
+                                        onClick={() =>
+                                          router.push(
+                                            '/portal/developers/apikeys',
+                                          )
+                                        }
                                       >
-                                        Click
-                                      </chakra.span>{' '}
-                                      to go to the developer portal.
-                                    </Text>
-                                  </Flex>
+                                        <chakra.span
+                                          fontWeight={'bold'}
+                                          textColor={'purple.500'}
+                                        >
+                                          Click
+                                        </chakra.span>{' '}
+                                        to go to the developer portal.
+                                      </Text>
+                                    </Flex>
+                                  ) : (
+                                    <></>
+                                  )}
                                   {name.toUpperCase() !=
                                   session?.user?.provider.toUpperCase() ? (
                                     <Button

--- a/apps/web/pages/portal/developers/apikeys.tsx
+++ b/apps/web/pages/portal/developers/apikeys.tsx
@@ -354,7 +354,8 @@ export async function getServerSideProps(context) {
     return { redirect: { destination: '/', permanent: false } };
   } else if (!user) {
     return { redirect: { destination: '/auth/login' } };
-  } else if (user.user?.role === 'USER' || user.user?.role === 'TRUSTED') {
+  } else if (user.user?.role === 'USER') {
+    //Normal users should't be able to acces api
     return { redirect: { destination: '/404' } };
   } else return { props: {} };
 }


### PR DESCRIPTION
## **Description**
- Trusted Users can now create API keys
- API page link is not displayed anymore for normal users
## **Issues**
- Fixes #314 
---

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
