### PR TITLE
Fix link api percentage limit inverted bug & Database vote query count error

### DIFF
--- a/apps/web/server/trpc/router/analysisApi.ts
+++ b/apps/web/server/trpc/router/analysisApi.ts
@@ -55,11 +55,7 @@ export const analysisApiRouter = router({
             // yesPercentage is pretty explanatory here.
             const yesPercentage = (yesCounts / totalVotes) * 100;
             // this checks if the yesPercentage is greater than or equal to the rating input. This just makes sure there is a minimum result.
-            if (yesPercentage <= input.rating) {
-              return true;
-            } else {
-              return false;
-            }
+            return yesPercentage >= input.rating;
           })
           // just loops through all of the results and formats the result;
           .map(result => {

--- a/apps/web/server/trpc/router/analysisApi.ts
+++ b/apps/web/server/trpc/router/analysisApi.ts
@@ -46,6 +46,9 @@ export const analysisApiRouter = router({
             ).length;
             //Total votes for current gameplay for percentage calculation and minvotes
             const totalVotes = yesCounts + noCounts;
+            if (totalVotes < input.minReviews) {
+              return false; //sort out submissions, which do not have minimum reviews
+            }
             // yesPercentage is pretty explanatory here.
             const yesPercentage = (yesCounts / totalVotes) * 100;
             // this checks if the yesPercentage is greater than or equal to the rating input. This just makes sure there is a minimum result.


### PR DESCRIPTION
## **Description**
- There was an API bug, where valid percentage was inverted 0% would return no valid videos and 100% would return all, due to an inverted comparison. That is now fixed
- The query for the votes queried all summed no votes over all videos while the yes votes only got queried on current video, which really screwed the percentages. That should be fixed now
---

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
