### PR TITLE
Replaced React image with Chakra image to fix server error

### DIFF
--- a/apps/web/pages/submissions/review.tsx
+++ b/apps/web/pages/submissions/review.tsx
@@ -7,6 +7,7 @@ import {
   useToast,
   Spinner,
   Tag,
+  Image as Img,
 } from '@chakra-ui/react';
 import { useState, useEffect, ReactElement } from 'react';
 import { useRouter } from 'next/router';
@@ -17,7 +18,6 @@ import { prisma } from '@server/db/client';
 import TurnstileWidget from '@components/TurnstileWidget';
 import Finished from '@components/Finished';
 import { getSession } from 'next-auth/react';
-import Image from 'next/image';
 import { games } from '@config/gameplay';
 import { GameplayType } from '@utils/zod/gameplay';
 interface ReviewItem {
@@ -193,7 +193,7 @@ export default function Review() {
                   <Flex direction={'row'}>
                     {/* User Icon */}
                     <Box>
-                      <Image
+                      <Img
                         src={
                           reviewItem != null &&
                           reviewItem.user != null &&
@@ -206,6 +206,7 @@ export default function Review() {
                         height={54}
                         style={{ borderRadius: '100%' }}
                         onClick={() => setRefreshState(refreshState + 1)}
+                        fallbackSrc="https://waldo.vision/battle_net.png"
                       />
                     </Box>
                     {/* Top titles */}


### PR DESCRIPTION
Checking for a nonexistent image externally on the server side makes no sense, so we use the Chakra Image which pulls on client-side thereby preventing those image not found server errors. Also you can specify an alternate image, if the image is not found anymore, which is set to the default battle.net image. We should avoid using the react image, since I think it is meant for self-hosted images.

## **Description**

- Replace react server side image with Chakra client side checked image to prevent server error spam.

## **Issues**

- [#330](https://github.com/waldo-vision/waldo/issues/330)

---

- [X] I have read the [Contributing Guide](https://docs.waldo.vision/en/getting-started/), and agree to follow the [Code of Conduct](https://docs.waldo.vision/legal/code-of-conduct/).
